### PR TITLE
Add username claim to ClaimsIdentity in ApplicationUserClaimsPrincipalFactory.CreateAsync

### DIFF
--- a/AspNetCore v6.0/MinimalAPI/Calabonga.Microservice.IdentityModule/Calabonga.Microservice.IdentityModule.Web/Definitions/Identity/ApplicationUserClaimsPrincipalFactory.cs
+++ b/AspNetCore v6.0/MinimalAPI/Calabonga.Microservice.IdentityModule/Calabonga.Microservice.IdentityModule.Web/Definitions/Identity/ApplicationUserClaimsPrincipalFactory.cs
@@ -40,6 +40,11 @@ public class ApplicationUserClaimsPrincipalFactory : UserClaimsPrincipalFactory<
 
         ((ClaimsIdentity)principal.Identity!).AddClaim(new Claim("framework", "nimble"));
 
+        if (!string.IsNullOrWhiteSpace(user.UserName))
+        {
+            ((ClaimsIdentity)principal.Identity!).AddClaim(new Claim(ClaimTypes.Name, user.UserName));
+        }
+
         if (!string.IsNullOrWhiteSpace(user.FirstName))
         {
             ((ClaimsIdentity)principal.Identity!).AddClaim(new Claim(ClaimTypes.GivenName, user.FirstName));


### PR DESCRIPTION
При авторизации через сервис на основе шаблона Identity из сервиса на основе простого шаблона микросервиса свойство Context.User?.Identity?.Name лежит null, так как при генерации токена в Identity модуле в ApplicationUserClaimsPrincipalFactory не добавляется username claim.