### PR TITLE
build: обновление NuGet-пакетов в шаблонах NET10.0

### DIFF
--- a/NET10.0/Calabonga.AspNetCoreRazorPages.Template/content/Calabonga.AspNetCoreRazorPages.Infrastructure/Calabonga.AspNetCoreRazorPages.Infrastructure.csproj
+++ b/NET10.0/Calabonga.AspNetCoreRazorPages.Template/content/Calabonga.AspNetCoreRazorPages.Infrastructure/Calabonga.AspNetCoreRazorPages.Infrastructure.csproj
@@ -7,17 +7,17 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Calabonga.UnitOfWork" Version="10.0.0" />
+		<PackageReference Include="Calabonga.UnitOfWork" Version="10.0.1" />
 		<PackageReference Include="Calabonga.PredicatesBuilder" Version="2.0.2" />
 		<PackageReference Include="Calabonga.Microservices.Core" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.6.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NET10.0/Calabonga.AspNetCoreRazorPages.Template/content/Calabonga.AspNetCoreRazorPages.Web/Calabonga.AspNetCoreRazorPages.Web.csproj
+++ b/NET10.0/Calabonga.AspNetCoreRazorPages.Template/content/Calabonga.AspNetCoreRazorPages.Web/Calabonga.AspNetCoreRazorPages.Web.csproj
@@ -7,18 +7,18 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" NoWarn="NU1605" />
-		<PackageReference Include="Calabonga.AspNetCore.AppDefinitions" Version="4.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" NoWarn="NU1605" />
+		<PackageReference Include="Calabonga.AspNetCore.AppDefinitions" Version="10.0.0" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
-		<PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+		<PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+		<PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.11" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-		<PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="7.6.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 	</ItemGroup>

--- a/NET10.0/Calabonga.Microservice.IdentityModule.Template/content/Calabonga.Microservice.IdentityModule.Infrastructure/Calabonga.Microservice.IdentityModule.Infrastructure.csproj
+++ b/NET10.0/Calabonga.Microservice.IdentityModule.Template/content/Calabonga.Microservice.IdentityModule.Infrastructure/Calabonga.Microservice.IdentityModule.Infrastructure.csproj
@@ -9,16 +9,16 @@
 
 	<ItemGroup>
 		<PackageReference Include="Calabonga.Results" Version="1.1.0" />
-		<PackageReference Include="Calabonga.UnitOfWork" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3">
+		<PackageReference Include="Calabonga.UnitOfWork" Version="10.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.6.1" />
 		<PackageReference Include="Calabonga.PredicatesBuilder" Version="2.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NET10.0/Calabonga.Microservice.IdentityModule.Template/content/Calabonga.Microservice.IdentityModule.Web/Calabonga.Microservice.IdentityModule.Web.csproj
+++ b/NET10.0/Calabonga.Microservice.IdentityModule.Template/content/Calabonga.Microservice.IdentityModule.Web/Calabonga.Microservice.IdentityModule.Web.csproj
@@ -17,26 +17,26 @@
 	<ItemGroup>
 		<PackageReference Include="Calabonga.Microservices.Core" Version="6.0.0" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
-		<PackageReference Include="Calabonga.AspNetCore.AppDefinitions" Version="4.0.0" />
+		<PackageReference Include="Calabonga.AspNetCore.AppDefinitions" Version="10.0.0" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
-		<PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+		<PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+		<PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="7.6.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
-		<PackageReference Include="System.Linq.Async" Version="7.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
+		<PackageReference Include="System.Linq.Async" Version="7.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NET10.0/Calabonga.Microservice.Module.Template/content/Calabonga.Microservice.Module.Infrastructure/Calabonga.Microservice.Module.Infrastructure.csproj
+++ b/NET10.0/Calabonga.Microservice.Module.Template/content/Calabonga.Microservice.Module.Infrastructure/Calabonga.Microservice.Module.Infrastructure.csproj
@@ -9,12 +9,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Calabonga.Results" Version="1.1.0" />
-		<PackageReference Include="Calabonga.UnitOfWork" Version="10.0.0" />
+		<PackageReference Include="Calabonga.UnitOfWork" Version="10.0.1" />
 		<PackageReference Include="Calabonga.PredicatesBuilder" Version="2.0.2" />
 		<PackageReference Include="Calabonga.Microservices.Core" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NET10.0/Calabonga.Microservice.Module.Template/content/Calabonga.Microservice.Module.Web/Calabonga.Microservice.Module.Web.csproj
+++ b/NET10.0/Calabonga.Microservice.Module.Template/content/Calabonga.Microservice.Module.Web/Calabonga.Microservice.Module.Web.csproj
@@ -8,29 +8,29 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Calabonga.AspNetCore.AppDefinitions" Version="4.0.0" />
+		<PackageReference Include="Calabonga.AspNetCore.AppDefinitions" Version="10.0.0" />
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
-		<PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+		<PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+		<PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" Version="10.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-		<PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="7.6.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 		<PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Что сделано

Обновлены версии NuGet-пакетов во всех трёх шаблонах папки `NET10.0/` (Module, IdentityModule, RazorPages), проекты `content/*.Infrastructure` и `content/*.Web`. Изменены только номера версий, окончания строк (CRLF) сохранены, файлы `*.Domain.csproj` не затронуты.

| Пакет | Было → Стало |
|---|---|
| Calabonga.AspNetCore.AppDefinitions | 4.0.0 → 10.0.0 |
| Microsoft.EntityFrameworkCore(.InMemory/.Design/.Relational/.Tools) | 10.0.3 → 10.0.11 |
| Microsoft.AspNetCore.* (JwtBearer, OpenIdConnect, OpenApi, QuickGrid.EFAdapter, Identity.EFCore) | 10.0.3 → 10.0.11 |
| Microsoft.Extensions.Caching.StackExchangeRedis | 10.0.3 → 10.0.11 |
| OpenIddict.AspNetCore / OpenIddict.EntityFrameworkCore | 7.2.0 → 7.6.1 |
| Mediator.Abstractions / Mediator.SourceGenerator | 3.0.1 → 3.0.2 |
| Swashbuckle.AspNetCore.SwaggerUI | 10.1.2 → 10.2.3 |
| Calabonga.UnitOfWork | 10.0.0 → 10.0.1 |
| System.Linq.Async | 7.0.0 → 7.0.1 |

`AppDefinitions 10.0.0` — это фактически один релиз (перевод на `net10.0` + миграция решения в `.slnx`), без изменений API. Шаблоны `NET10.0/` уже таргетируют только `net10.0`.

## Проверка

- ✅ `dotnet build` трёх решений `NET10.0/` в Release — 0 ошибок
- ✅ `dotnet new` генерация проектов из `microservice-oidd` и `microservice`
- ✅ `dotnet build` сгенерированных проектов — 0 ошибок
- ✅ Запуск STS (:10001) + API (:20001), reflection-загрузчик применил все `AppDefinition` (17/17 и 14/14)
- ✅ Авторизация между шаблонами по `client_credentials`: без токена → `401`; запрос токена → RS256 JWT; с токеном → `200` + данные

🤖 Generated with [Claude Code](https://claude.com/claude-code)