### PR TITLE
fix: корректный JSON в matrix-output workflow publish-templates

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -55,7 +55,9 @@ jobs:
               *)   echo 'packages=["${{ inputs.target }}"]'            >> "$GITHUB_OUTPUT" ;;
             esac
           else
-            echo "packages=${{ steps.filter.outputs.changes }}" >> "$GITHUB_OUTPUT"
+            # single quotes: the runner expands ${{ }}, bash must not touch the
+            # inner JSON quotes (double quotes here collapse ["a","b"] to [a,b]).
+            echo 'packages=${{ steps.filter.outputs.changes }}' >> "$GITHUB_OUTPUT"
           fi
 
   publish:


### PR DESCRIPTION
## Проблема

[Ран Publish templates](https://github.com/Calabonga/Microservice-Template/actions/runs/33057443279) упал: джоба `changes` отработала успешно, но джоба `publish` вообще не создалась, и весь ран завершился с ошибкой.

## Причина

В `else`-ветке шага «Decide package list» значение подставлялось в `echo` с двойными кавычками:

```bash
echo "packages=${{ steps.filter.outputs.changes }}" >> "$GITHUB_OUTPUT"
```

После того как runner раскрывает `${{ }}` в `["module","identity","razorpages"]`, bash видит строку с чередующимися двойными кавычками и схлопывает внутренние кавычки массива:

```bash
echo "packages=["module","identity","razorpages"]"
# → packages=[module,identity,razorpages]   (невалидный JSON)
```

`fromJSON(...)` в `strategy.matrix` на таком входе падает, матрица не разворачивается, джоба `publish` не создаётся → ран `failure`.

В ветке `workflow_dispatch` используются одинарные кавычки, поэтому баг проявлялся только на `push`.

## Исправление

Одинарные кавычки: `${{ }}` по-прежнему раскрывает runner, а bash не трогает внутренние кавычки JSON-массива.

🤖 Generated with [Claude Code](https://claude.com/claude-code)