### PR TITLE
fix: убрать пустое выражение ${{ }} из комментария в publish-templates

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -55,8 +55,9 @@ jobs:
               *)   echo 'packages=["${{ inputs.target }}"]'            >> "$GITHUB_OUTPUT" ;;
             esac
           else
-            # single quotes: the runner expands ${{ }}, bash must not touch the
-            # inner JSON quotes (double quotes here collapse ["a","b"] to [a,b]).
+            # Single quotes on purpose: the runner substitutes the expression,
+            # and bash must not strip the JSON array quotes. With double quotes
+            # bash collapses [ "a", "b" ] into [ a, b ] and fromJSON() then fails.
             echo 'packages=${{ steps.filter.outputs.changes }}' >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Проблема

После мержа #68 [ран Publish templates](https://github.com/Calabonga/Microservice-Template/actions/runs/33058403637) снова упал — на этот раз **не создалось ни одной джобы** (0 jobs), workflow не скомпилировался.

## Причина

В #68 в комментарий шага «Decide package list» попал текст `${{ }}`:

```bash
# single quotes: the runner expands ${{ }}, bash must not touch the
```

GitHub Actions вычисляет шаблоны `${{ ... }}` по всему значению `run:`, включая строки, которые для bash являются комментариями. Пустое `${{ }}` — синтаксическая ошибка выражения → workflow невалиден → ран падает целиком ещё до запуска джоб.

## Исправление

Комментарий переписан без фигурных скобок выражения. Сама логика фикса из #68 (одинарные кавычки вокруг подстановки JSON-массива) не менялась.

🤖 Generated with [Claude Code](https://claude.com/claude-code)