### PR TITLE
fix: пушить .nupkg по одному, без glob-шаблона

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -94,7 +94,17 @@ jobs:
         run: dotnet restore "${{ steps.proj.outputs.path }}"
 
       - name: Pack
-        run: dotnet pack "${{ steps.proj.outputs.path }}" --configuration Release --no-restore --output ${{ runner.temp }}/pkg
+        run: dotnet pack "${{ steps.proj.outputs.path }}" --configuration Release --no-restore --output "${{ runner.temp }}/pkg"
 
       - name: Push to nuget.org
-        run: dotnet nuget push "${{ runner.temp }}/pkg/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        shell: pwsh
+        # The runner shell is pwsh, which does not glob-expand the star pattern
+        # for the native command, and dotnet nuget push cannot resolve the
+        # wildcard itself on Windows. Enumerate the files and push one by one.
+        run: |
+          $dir = "${{ runner.temp }}/pkg"
+          $packages = Get-ChildItem -Path $dir -Filter *.nupkg
+          if (-not $packages) { throw "No .nupkg found in $dir" }
+          foreach ($package in $packages) {
+            dotnet nuget push $package.FullName --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }


### PR DESCRIPTION
## Контекст

После мержа #69 matrix-джобы наконец разворачиваются: [ран 33058872149](https://github.com/Calabonga/Microservice-Template/actions/runs/33058872149) прошёл `changes` + три `publish (module/identity/razorpages)`, все шаги до `Pack` включительно — зелёные. Падает только `Push to nuget.org`.

## Проблема

```
Successfully created package 'D:\a\_temp\pkg\Calabonga.Microservice.Module.Template.10.0.3-g8efec40931.nupkg'.
...
error: File does not exist (D:\a\_temp/pkg/*.nupkg).
```

Пакет создаётся, но `dotnet nuget push "${{ runner.temp }}/pkg/*.nupkg"` не находит файл: shell раннера на `windows-latest` — pwsh, он не раскрывает `*` для нативной команды, а сам `dotnet nuget push` не резолвит wildcard на Windows (плюс смешанные слэши в `${{ runner.temp }}` → `D:\a\_temp/pkg/*.nupkg`).

## Исправление

Шаг `Push to nuget.org` переведён на `shell: pwsh` и перечисляет пакеты через `Get-ChildItem`, пушит каждый по `FullName`. Если пакетов нет — явный `throw`. Путь в `--output` у `Pack` взят в кавычки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)