### PR TITLE
docs: описать изменения после версии 10.0.0 в README

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -13,6 +13,28 @@ To install templates (`Visual Studio`, `Rider`, `dotnet CLI`) please, read [wiki
 
 ## Nimble Framework History
 
+### 2026-08-27
+
+The changes affect all three templates in the `NET10.0/` folder (`Calabonga.Microservice.Module.Template`, `Calabonga.Microservice.IdentityModule.Template`, `Calabonga.AspNetCoreRazorPages.Template`).
+
+* Updated NuGet packages in the `content/*.Infrastructure` and `content/*.Web` projects of all three templates:
+    * `Calabonga.AspNetCore.AppDefinitions` 4.0.0 → 10.0.0
+    * `Microsoft.EntityFrameworkCore.*` and `Microsoft.AspNetCore.*` 10.0.3 → 10.0.11
+    * `Microsoft.Extensions.Caching.StackExchangeRedis` 10.0.3 → 10.0.11
+    * `OpenIddict.AspNetCore` and `OpenIddict.EntityFrameworkCore` 7.2.0 → 7.6.1
+    * `Mediator.Abstractions` and `Mediator.SourceGenerator` 3.0.1 → 3.0.2
+    * `Swashbuckle.AspNetCore.SwaggerUI` 10.1.2 → 10.2.3
+    * `Calabonga.UnitOfWork` 10.0.0 → 10.0.1
+    * `System.Linq.Async` 7.0.0 → 7.0.1
+* Automated template publishing in CI:
+    * Three separate workflows (`module.yml`, `module-auth.yml`, `razor-pages.yml`) replaced with a single `publish-templates.yml`.
+    * Versioning via `Nerdbank.GitVersioning`: each package's patch number is derived from the height of commits touching that specific template's folder, so packages are incremented independently. Changing minor/major is done by editing `version` in `version.json`.
+    * Trigger — `push` to `master` with paths `NET10.0/**`; `dorny/paths-filter` detects the affected templates and a matrix job publishes only those. A manual `workflow_dispatch` with a target choice (`all` / `module` / `identity` / `razorpages`) is also available for a forced re-release.
+    * `nuget push --skip-duplicate` kept: a run without a version change is a no-op. Updated `actions/checkout` → v4 (`fetch-depth: 0`), `setup-dotnet` → v4.
+* Added the instructions file `.claude/CLAUDE.md` and a set of rules `.claude/rules/*` (architecture, naming conventions, C# style, testing, workflow) — context for working with the repository through Claude Code.
+* Added the `nuget-update` skill (`.claude/skills/nuget-update/`) that automates checking and bumping NuGet package versions in the `NET10.0` templates: a read-only script compares versions against nuget.org, then patch + minor are applied automatically, major only after confirmation, followed by building the three solutions and an end-to-end Module ↔ IdentityModule authorization test.
+* `README.md`: `Calabonga.AspNetCoreRazorPages.Template` added to the package list.
+
 ### 2026-02-14 Version 10.0.0
 
 * All projects in solution were moved to NET10.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,28 @@
 
 ## История Nimble Framework
 
+### 2026-08-27 Изменения после версии 10.0.0
+
+Изменения касаются всех трёх шаблонов в папке `NET10.0/` (`Calabonga.Microservice.Module.Template`, `Calabonga.Microservice.IdentityModule.Template`, `Calabonga.AspNetCoreRazorPages.Template`).
+
+* Обновлены NuGet-пакеты в проектах `content/*.Infrastructure` и `content/*.Web` всех трёх шаблонов:
+    * `Calabonga.AspNetCore.AppDefinitions` 4.0.0 → 10.0.0
+    * `Microsoft.EntityFrameworkCore.*` и `Microsoft.AspNetCore.*` 10.0.3 → 10.0.11
+    * `Microsoft.Extensions.Caching.StackExchangeRedis` 10.0.3 → 10.0.11
+    * `OpenIddict.AspNetCore` и `OpenIddict.EntityFrameworkCore` 7.2.0 → 7.6.1
+    * `Mediator.Abstractions` и `Mediator.SourceGenerator` 3.0.1 → 3.0.2
+    * `Swashbuckle.AspNetCore.SwaggerUI` 10.1.2 → 10.2.3
+    * `Calabonga.UnitOfWork` 10.0.0 → 10.0.1
+    * `System.Linq.Async` 7.0.0 → 7.0.1
+* Автоматическая публикация шаблонов в CI:
+    * Три отдельных workflow (`module.yml`, `module-auth.yml`, `razor-pages.yml`) заменены одним `publish-templates.yml`.
+    * Версионирование через `Nerdbank.GitVersioning`: patch-номер каждого пакета считается по высоте коммитов, затронувших папку конкретного шаблона, поэтому пакеты инкрементируются независимо. Смена minor/major — правкой `version` в `version.json`.
+    * Триггер — `push` в `master` с путями `NET10.0/**`; `dorny/paths-filter` определяет затронутые шаблоны, и matrix-job публикует только их. Также доступен ручной запуск `workflow_dispatch` с выбором цели (`all` / `module` / `identity` / `razorpages`) для форс-переиздания.
+    * `nuget push --skip-duplicate` сохранён: прогон без смены версии — no-op. Обновлены `actions/checkout` → v4 (`fetch-depth: 0`), `setup-dotnet` → v4.
+* Добавлен файл инструкций `.claude/CLAUDE.md` и набор правил `.claude/rules/*` (архитектура, соглашения об именовании, стиль C#, тестирование, рабочий процесс) — контекст для работы с репозиторием через Claude Code.
+* Добавлен скилл `nuget-update` (`.claude/skills/nuget-update/`) для автоматической проверки и подъёма версий NuGet-пакетов в шаблонах `NET10.0`: read-only-скрипт сверяет версии с nuget.org, затем patch + minor применяются автоматически, major — только с подтверждения, в конце — сборка трёх решений и сквозной тест авторизации Module ↔ IdentityModule.
+* `README.md`: в список пакетов добавлен `Calabonga.AspNetCoreRazorPages.Template`.
+
 ### 2026-02-14 Версия 10.0.0
 
 * Проекты в решении переведены на NET10.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## История Nimble Framework
 
-### 2026-08-27 Изменения после версии 10.0.0
+### 2026-08-27
 
 Изменения касаются всех трёх шаблонов в папке `NET10.0/` (`Calabonga.Microservice.Module.Template`, `Calabonga.Microservice.IdentityModule.Template`, `Calabonga.AspNetCoreRazorPages.Template`).
 


### PR DESCRIPTION
## Что сделано

В `README.md` добавлен раздел истории **«2026-08-27 Изменения после версии 10.0.0»**. Отдельного релиза версии не было — все изменения периода относятся к инфраструктуре репозитория и зависимостям.

### Содержание записи

- **Обновление NuGet-пакетов** во всех трёх шаблонах `NET10.0` (AppDefinitions 4.0.0→10.0.0, EF Core / ASP.NET Core 10.0.3→10.0.11, OpenIddict 7.2.0→7.6.1, Mediator 3.0.1→3.0.2, SwaggerUI 10.1.2→10.2.3, UnitOfWork 10.0.0→10.0.1, System.Linq.Async 7.0.0→7.0.1).
- **Автопубликация в CI**: три workflow заменены одним `publish-templates.yml`; версионирование через `Nerdbank.GitVersioning` по высоте коммитов на папку шаблона; триггер `push` в `master` по путям `NET10.0/**` + ручной `workflow_dispatch`.
- Добавлены **`.claude/CLAUDE.md`** и **`.claude/rules/*`**.
- Добавлен **скилл `nuget-update`**.
- В список пакетов README добавлен `Calabonga.AspNetCoreRazorPages.Template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)