### PR TITLE
chore: форсировать PublicRelease=true при упаковке шаблонов

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -94,7 +94,11 @@ jobs:
         run: dotnet restore "${{ steps.proj.outputs.path }}"
 
       - name: Pack
-        run: dotnet pack "${{ steps.proj.outputs.path }}" --configuration Release --no-restore --output "${{ runner.temp }}/pkg"
+        # PublicRelease=true forces Nerdbank.GitVersioning to emit a clean version
+        # (10.0.x) with no -g<commit> pre-release suffix, regardless of how the run
+        # was triggered (push or manual workflow_dispatch, which checks out a
+        # detached HEAD that publicReleaseRefs cannot match on its own).
+        run: dotnet pack "${{ steps.proj.outputs.path }}" --configuration Release --no-restore -p:PublicRelease=true --output "${{ runner.temp }}/pkg"
 
       - name: Push to nuget.org
         shell: pwsh


### PR DESCRIPTION
## Проблема

Nerdbank.GitVersioning добавлял pre-release-суффикс `-g<commit>` (например `10.0.3-gd8f9019a38`) к версии NuGet-пакета, когда запуск workflow не распознавался как публичный релиз. Признак публичного релиза — совпадение git-ref с `publicReleaseRefs` (`^refs/heads/master$`), но `actions/checkout` оставляет detached HEAD, и при ручном `workflow_dispatch` совпадения нет → `PublicRelease=false` → суффикс.

## Решение

Явный `-p:PublicRelease=true` в шаге **Pack** workflow `publish-templates.yml`. Шаг выполняется в matrix-стратегии, поэтому исправление действует на все три шаблона (module, identity, razorpages). Версия теперь чистая `10.0.x` при любом триггере — и push в master, и ручной запуск.

`publicReleaseRefs` в трёх `version.json` оставлены без изменений — они не мешают и корректно работают для локальных сборок на master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)